### PR TITLE
reset file pointer after copying

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install system dependencies
+      run: sudo apk add gcc musl-dev python3-dev libffi-dev openssl-dev cargo
+
     - name: Install requirements
       run: |
+        pip install --upgrade pip
         # scheming
         pip install -e git+https://github.com/ckan/ckanext-scheming.git@release-2.0.0#egg=ckanext-scheming
         pip install -r https://raw.githubusercontent.com/ckan/ckanext-scheming/release-2.0.0/requirements.txt

--- a/ckanext/ddi/blueprints.py
+++ b/ckanext/ddi/blueprints.py
@@ -233,6 +233,7 @@ class ImportView(MethodView):
         with os.fdopen(fd, 'wb') as output_file:
             fileobj.seek(0)
             shutil.copyfileobj(fileobj, output_file)
+            fileobj.seek(0)
         return file_path
 
 


### PR DESCRIPTION
This fixes an issue where DDI just writes a 0 bytes file to s3 instead of uploading the actual DDI XML file when used with the cloudstorage plugin.

I'm not 100% sure why this doesn't manifest when using the local file storage backend but I guess the local storage backend can just copy the temp file from A to B whereas cloudstorage needs to actually read the `SpooledTemporaryFile` in order to perform the upload to S3.

f0ea172 is incidental to this PR, but needed to get the build to pass