### PR TITLE
Capture country codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# OKF DDI Changelog
+
+## v2.0.3 - 2021-11-29
+New features:
+ - Start capturing country codes from `nation` field [#9](https://github.com/okfn/ckanext-ddi/pull/9)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+DDI
+===
+
+The Data Documentation Initiative (DDI) is an international standard available at [ddialliance.org](https://ddialliance.org/)
+
 ckanext-ddi
 ===========
 

--- a/ckanext/ddi/importer/metadata.py
+++ b/ckanext/ddi/importer/metadata.py
@@ -263,7 +263,8 @@ class CkanMetadata(object):
             'unit_of_analysis',
             'description_of_scope',
             'country',
-            'geographic_coverage',
+            'country_codes',
+            'geog_coverage',
             'time_period_covered',
             'universe',
             'primary_investigator',
@@ -357,7 +358,13 @@ class DdiCkanMetadata(CkanMetadata):
             ),
             separator=', '
         ),
-        'geographic_coverage': XPathTextValue(
+        'country_codes': ArrayTextValue(
+            XPathMultiTextValue(
+                "//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation/@abbr"  # noqa
+            ),
+            separator=', '
+        ),
+        'geog_coverage': XPathTextValue(
             "//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:geogCover"  # noqa
         ),
         'time_period_covered': ArrayTextValue(

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.0.2'
+version = '2.0.3'
 
 setup(
     name='ckanext-ddi',


### PR DESCRIPTION
Related to [UNHCR#750](https://github.com/okfn/ckanext-unhcr/issues/750)
UNHCR changes [UNHCR#755](https://github.com/okfn/ckanext-unhcr/pull/755)

This PR:
 - Start capturing country codes (to be used at UNHCR extension)
 - Change geographic_coverage -> geog_coverage to allow UNHCR extension to use it
   - This seems to be a valuable field in DDI documents and maybe we don't want to drop it.
 - Add a note: _What's DDI?_