### PR TITLE
Force geographies to be present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OKF DDI Changelog
 
+## v2.04 - 2022-02-01
+New features:
+ - Force to include `country_codes` (for UNHCR `geographies`) [#10](https://github.com/okfn/ckanext-ddi/pull/10)
+
 ## v2.0.3 - 2021-11-29
 New features:
  - Start capturing country codes from `nation` field [#9](https://github.com/okfn/ckanext-ddi/pull/9)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Available options are:
 ckanext.ddi.default_license = CC0-1.0
 ckanext.ddi.allow_duplicates = True
 ckanext.ddi.override_datasets = False
-ckanext.ddi.default_conuntry_code = WORLD
+ckanext.ddi.default_country_code = WORLD
 ```
 
 The `config_file` is simply the path to the DDI-specific configuration of this extension (see below).

--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ Available options are:
 ckanext.ddi.default_license = CC0-1.0
 ckanext.ddi.allow_duplicates = True
 ckanext.ddi.override_datasets = False
-ckanext.ddi.default_country_code = WORLD
+ckanext.ddi.default_country_code = UNSPECIFIED
 ```
 
 The `config_file` is simply the path to the DDI-specific configuration of this extension (see below).
 The `default_license` allows a user to configure a license that is used for all DDI imports, if the license is not specified explicitly.
 The `allow_duplicates` option is used to determine, if duplicate datasets are allowed or not. Duplicates are determined by the unique `id_number` attribute (defaults to `False`).
 With `override_datasets` you can specify, if you import a dataset that already exists, if a new dataset should be created or if the existing one should be overridden (defaults to `False`).
-The `default_conuntry_code` option will force all datasets to have a country code (defaults to `WORLD` because UNHCR extension use it).
+The `default_country_code` option will force all datasets to have a country code (defaults to `UNSPECIFIED` because UNHCR extension use it).
 
 ### Web interface
 

--- a/README.md
+++ b/README.md
@@ -48,18 +48,20 @@ are installed as well.
 ## Configuration
 
 ### CKAN configuration (production.ini)
-Three options are available:
+Available options are:
 
 ```bash
 ckanext.ddi.default_license = CC0-1.0
 ckanext.ddi.allow_duplicates = True
 ckanext.ddi.override_datasets = False
+ckanext.ddi.default_conuntry_code = WORLD
 ```
 
 The `config_file` is simply the path to the DDI-specific configuration of this extension (see below).
 The `default_license` allows a user to configure a license that is used for all DDI imports, if the license is not specified explicitly.
 The `allow_duplicates` option is used to determine, if duplicate datasets are allowed or not. Duplicates are determined by the unique `id_number` attribute (defaults to `False`).
 With `override_datasets` you can specify, if you import a dataset that already exists, if a new dataset should be created or if the existing one should be overridden (defaults to `False`).
+The `default_conuntry_code` option will force all datasets to have a country code (defaults to `WORLD` because UNHCR extension use it).
 
 ### Web interface
 

--- a/ckanext/ddi/importer/ddiimporter.py
+++ b/ckanext/ddi/importer/ddiimporter.py
@@ -198,7 +198,10 @@ class DdiImporter(HarvesterBase):
         if not pkg_dict.get('country_codes'):
             # geographies fields is now a required field.
             # We need to ensure any dataset to have a "geographies" field filled
-            pkg_dict['country_codes'] = tk.config.get('ckanext.ddi.default_country_code', 'UNSPECIFIED')
+            pkg_dict['country_codes'] = tk.config.get(
+                'ckanext.ddi.default_country_code',
+                'UNSPECIFIED'
+            )
 
         pkg_dict['ddi'] = True
 

--- a/ckanext/ddi/importer/ddiimporter.py
+++ b/ckanext/ddi/importer/ddiimporter.py
@@ -15,6 +15,9 @@ import ckanapi
 import logging
 log = logging.getLogger(__name__)
 
+# geographies fields is now a required field.
+# We need to ensure any dataset to have a "geographies" field filled
+DEFAULT_COUNTRY_CODE = 'WORLD'
 
 class DdiImporter(HarvesterBase):
     def __init__(self, username=None):
@@ -194,6 +197,9 @@ class DdiImporter(HarvesterBase):
 
         if pkg_dict.get('abbreviation'):
             pkg_dict['short_title'] = pkg_dict['abbreviation']
+
+        if not pkg_dict.get('country_codes'):
+            pkg_dict['country_codes'] = DEFAULT_COUNTRY_CODE
 
         pkg_dict['ddi'] = True
 

--- a/ckanext/ddi/importer/ddiimporter.py
+++ b/ckanext/ddi/importer/ddiimporter.py
@@ -15,9 +15,6 @@ import ckanapi
 import logging
 log = logging.getLogger(__name__)
 
-# geographies fields is now a required field.
-# We need to ensure any dataset to have a "geographies" field filled
-DEFAULT_COUNTRY_CODE = 'WORLD'
 
 class DdiImporter(HarvesterBase):
     def __init__(self, username=None):
@@ -199,7 +196,9 @@ class DdiImporter(HarvesterBase):
             pkg_dict['short_title'] = pkg_dict['abbreviation']
 
         if not pkg_dict.get('country_codes'):
-            pkg_dict['country_codes'] = DEFAULT_COUNTRY_CODE
+            # geographies fields is now a required field.
+            # We need to ensure any dataset to have a "geographies" field filled
+            pkg_dict['country_codes'] = tk.config.get('ckanext.ddi.default_conuntry_code', 'WORLD')
 
         pkg_dict['ddi'] = True
 

--- a/ckanext/ddi/importer/ddiimporter.py
+++ b/ckanext/ddi/importer/ddiimporter.py
@@ -198,7 +198,7 @@ class DdiImporter(HarvesterBase):
         if not pkg_dict.get('country_codes'):
             # geographies fields is now a required field.
             # We need to ensure any dataset to have a "geographies" field filled
-            pkg_dict['country_codes'] = tk.config.get('ckanext.ddi.default_conuntry_code', 'WORLD')
+            pkg_dict['country_codes'] = tk.config.get('ckanext.ddi.default_country_code', 'WORLD')
 
         pkg_dict['ddi'] = True
 

--- a/ckanext/ddi/importer/ddiimporter.py
+++ b/ckanext/ddi/importer/ddiimporter.py
@@ -198,7 +198,7 @@ class DdiImporter(HarvesterBase):
         if not pkg_dict.get('country_codes'):
             # geographies fields is now a required field.
             # We need to ensure any dataset to have a "geographies" field filled
-            pkg_dict['country_codes'] = tk.config.get('ckanext.ddi.default_country_code', 'WORLD')
+            pkg_dict['country_codes'] = tk.config.get('ckanext.ddi.default_country_code', 'UNSPECIFIED')
 
         pkg_dict['ddi'] = True
 


### PR DESCRIPTION
The `country_code` field will be used as Geography ion UNHCR extension
It's now [required](https://github.com/okfn/ckanext-unhcr/pull/777)
