### PR TITLE
Prepare DDI for CKAN 2.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,8 +56,8 @@ jobs:
         pip install -e git+https://github.com/ckan/ckanext-scheming.git@release-2.0.0#egg=ckanext-scheming
         pip install -r https://raw.githubusercontent.com/ckan/ckanext-scheming/release-2.0.0/requirements.txt
         # harvest
-        pip install -e git+https://github.com/ckan/ckanext-harvest.git@v1.4.1#egg=ckanext-harvest
-        pip install -r https://raw.githubusercontent.com/ckan/ckanext-harvest/v1.4.1/pip-requirements.txt
+        pip install -e git+https://github.com/ckan/ckanext-harvest.git@v1.4.2#egg=ckanext-harvest
+        pip install -r https://raw.githubusercontent.com/ckan/ckanext-harvest/v1.4.2/requirements.txt
         # DDI
         pip install -r requirements.txt
         pip install -r dev-requirements.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,8 +56,8 @@ jobs:
         pip install -e git+https://github.com/ckan/ckanext-scheming.git@release-2.0.0#egg=ckanext-scheming
         pip install -r https://raw.githubusercontent.com/ckan/ckanext-scheming/release-2.0.0/requirements.txt
         # harvest
-        pip install -e git+https://github.com/ckan/ckanext-harvest.git@v1.3.2#egg=ckanext-harvest
-        pip install -r https://raw.githubusercontent.com/ckan/ckanext-harvest/v1.3.2/pip-requirements.txt
+        pip install -e git+https://github.com/ckan/ckanext-harvest.git@v1.4.1#egg=ckanext-harvest
+        pip install -r https://raw.githubusercontent.com/ckan/ckanext-harvest/v1.4.1/pip-requirements.txt
         # DDI
         pip install -r requirements.txt
         pip install -r dev-requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # OKF DDI Changelog
 
+## v2.1.0 - 2023-02-07
+
+Preparing DDI for CKAN 2.10
+
+New features:
+ - Started using CSRF for CKAN 2.10
+ - Upgrade `ckanext-harvest` for tests
+
 ## v2.04 - 2022-02-01
 New features:
  - Force to include `country_codes` (for UNHCR `geographies`) [#10](https://github.com/okfn/ckanext-ddi/pull/10)

--- a/ckanext/ddi/templates/package/import_package_form.html
+++ b/ckanext/ddi/templates/package/import_package_form.html
@@ -35,6 +35,7 @@
 
 
 <form class="dataset-form form-horizontal" method="post" enctype="multipart/form-data" action="import" data-module="basic-form">
+  {{ h.csrf_input() if 'csrf_input' in h }}
 
   {% block stages %}
     {{ h.snippet('package/snippets/stages.html', stages=stage) }}


### PR DESCRIPTION
Related to [UNHCR#969](https://github.com/okfn/ckanext-unhcr/issues/969)

Also, upgrade `ckanext-harvest` for tests

New tag: `v2.1.0`
